### PR TITLE
More implementation of trait OCamlDesc

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@
 [![Docs](https://docs.rs/badgen/badge.svg)](https://o1-labs.github.io/ocaml-gen/)
 # OCaml-gen
 
-This Rust library allows you to automatically generate OCaml bindings for your Rust code. It is meant to be used in conjunction with [`ocaml-rs`](https://github.com/zshipko/ocaml-rs).
+## Motivation
+
+[`ocaml-rs`](https://github.com/zshipko/ocaml-rs) provides functions and
+wrappers to interact with the OCaml runtime which implements a garbage collector
+to manage memory automatically. The library allows developers to write functions
+in Rust that can be called from OCaml and vice versa. It provides automatic
+conversion between OCaml and Rust value representations. The users can use
+macros on the Rust side like `ocaml::FromValue` and `ocaml::ToValue` to convert
+back and forth the values without thinking about the garbage
+collector.
+Macros `ocaml::func` in conjunction with `ocaml::sig` can be used on functions
+to generate codes which will be compatible with the OCaml runtime.
+More information is available in the [ocaml-rs book](https://zshipko.github.io/ocaml-rs/).
+
+Even if `ocaml-rs` provides some macros, the user will need to write the OCaml
+definitions with the corresponding types and use external definitions. Also,
+macros to access nested values in structures are not provided in `ocaml-rs`.
+The goal of `ocaml-gen` and `ocaml-gen-derive` is to provide automatic binding
+generations and to add macros easing the development of large applications.
+It is meant to be used in conjunction with [`ocaml-rs`](https://github.com/zshipko/ocaml-rs).
 
 **SECURITY WARNING: this is still an experimental library, you should verify that the bindings generated are correct if you are using this in production**.
 

--- a/dune-project
+++ b/dune-project
@@ -16,5 +16,7 @@
  (depends
   (dune (>= 3.0))
   (ocaml (and (>= 4.12) (< 5.0)))
+  (conf-rust (>= 0.1))
+  alcotest
  )
 )

--- a/dune-project
+++ b/dune-project
@@ -18,5 +18,7 @@
   (ocaml (and (>= 4.12) (< 5.0)))
   (conf-rust (>= 0.1))
   alcotest
+  qcheck
+  qcheck-alcotest
  )
 )

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -139,6 +139,16 @@ impl OCamlDesc for bool {
     }
 }
 
+impl OCamlDesc for i32 {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
+        "int32".to_string()
+    }
+
+    fn unique_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
 impl<T> OCamlDesc for ocaml::Pointer<'_, T>
 where
     T: OCamlDesc,

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -54,16 +54,6 @@ impl OCamlDesc for &[u8] {
     }
 }
 
-impl OCamlDesc for Vec<u8> {
-    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
-        "bytes".to_string()
-    }
-
-    fn unique_id() -> u128 {
-        const_random!(u128)
-    }
-}
-
 impl<T> OCamlDesc for Vec<T>
 where
     T: OCamlDesc,

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -34,6 +34,16 @@ where
     }
 }
 
+impl OCamlDesc for u8 {
+    fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
+        "char".to_string()
+    }
+
+    fn unique_id() -> u128 {
+        const_random!(u128)
+    }
+}
+
 impl OCamlDesc for [u8; 32] {
     fn ocaml_desc(_env: &Env, _generics: &[&str]) -> String {
         "bytes".to_string()

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -3,6 +3,10 @@
 //! The OCaml description should be the corresponding data types in OCaml
 //! This should correspond to the mapping defined in the ocaml-rs book:
 //! `<https://github.com/zshipko/ocaml-rs/blob/v1.0.0-beta.4/doc/src/02_type_conversion.md>`
+//! FIXME:
+//! Unsigned types like uint16, uint32 and uint64 are not implemented as OCaml
+//! does not provide types in the Stdlib for it. A custom block should be used.
+//! Using [Stdint](https://github.com/andrenth/ocaml-stdint/) could be a solution.
 
 use crate::{Env, OCamlDesc};
 use const_random::const_random;

--- a/ocaml-gen/src/conv.rs
+++ b/ocaml-gen/src/conv.rs
@@ -1,5 +1,8 @@
 //! Implementations of [`crate::OCamlDesc`] for types
 //! that have natural equivalents in OCaml.
+//! The OCaml description should be the corresponding data types in OCaml
+//! This should correspond to the mapping defined in the ocaml-rs book:
+//! `<https://github.com/zshipko/ocaml-rs/blob/v1.0.0-beta.4/doc/src/02_type_conversion.md>`
 
 use crate::{Env, OCamlDesc};
 use const_random::const_random;

--- a/ocamlgen-test.opam
+++ b/ocamlgen-test.opam
@@ -11,6 +11,8 @@ depends: [
   "ocaml" {>= "4.12" & < "5.0"}
   "conf-rust" {>= "0.1"}
   "alcotest"
+  "qcheck"
+  "qcheck-alcotest"
   "odoc" {with-doc}
 ]
 build: [

--- a/ocamlgen-test.opam
+++ b/ocamlgen-test.opam
@@ -9,6 +9,8 @@ bug-reports: "https://github.com/o1-labs/ocaml-gen/issues"
 depends: [
   "dune" {>= "3.0" & >= "3.0"}
   "ocaml" {>= "4.12" & < "5.0"}
+  "conf-rust" {>= "0.1"}
+  "alcotest"
   "odoc" {with-doc}
 ]
 build: [

--- a/tests/dune
+++ b/tests/dune
@@ -38,7 +38,7 @@
  (public_name ocamlgen_test)
  (package ocamlgen-test)
  (modules ocamlgen_test bindings)
- (libraries alcotest)
+ (libraries alcotest qcheck qcheck-alcotest)
  (foreign_archives ocamlgen_test_stubs))
 
 ;; rule for running the tests (runs the executable and apply diff on the

--- a/tests/dune
+++ b/tests/dune
@@ -31,22 +31,18 @@
      bindings.ml
      (run cargo run --bin main --release --target-dir %{project_root}/target))))))
 
-;; test library
-
-(library
- (name ocamlgen_test_lib)
- (public_name ocamlgen-test)
- (modules lib bindings)
- (foreign_archives ocamlgen_test_stubs))
-
-;; test executable (links to the library)
+;; Generate an executable for testing
 
 (executable
  (name ocamlgen_test)
- (modules ocamlgen_test)
- (libraries ocamlgen_test_lib))
+ (public_name ocamlgen_test)
+ (package ocamlgen-test)
+ (modules ocamlgen_test bindings)
+ (libraries alcotest)
+ (foreign_archives ocamlgen_test_stubs))
 
-;; rule for running the tests (runs the executable)
+;; rule for running the tests (runs the executable and apply diff on the
+;; generated bindings)
 
 (rule
  (alias runtest)

--- a/tests/expected_bindings.ml
+++ b/tests/expected_bindings.ml
@@ -15,6 +15,7 @@ external fn_six_parameters : Car.t -> int -> int -> int -> int -> int -> Car.t =
 external test_add_i32 : int32 -> int32 -> int32 = "test_add_i32"
 external test_add_usize : int -> int -> int = "test_add_usize"
 external test_bytes_get : bytes -> int -> char = "test_bytes_get"
+external test_get_ascii_code : char -> int32 = "test_get_ascii_code"
 
 module Toyota = struct 
   type nonrec t = Car.t

--- a/tests/expected_bindings.ml
+++ b/tests/expected_bindings.ml
@@ -14,6 +14,7 @@ external fn_five_parameters : Car.t -> int -> int -> int -> int -> Car.t = "fn_f
 external fn_six_parameters : Car.t -> int -> int -> int -> int -> int -> Car.t = "fn_six_parameters_bytecode" "fn_six_parameters"
 external test_add_i32 : int32 -> int32 -> int32 = "test_add_i32"
 external test_add_usize : int -> int -> int = "test_add_usize"
+external test_bytes_get : bytes -> int -> char = "test_bytes_get"
 
 module Toyota = struct 
   type nonrec t = Car.t

--- a/tests/expected_bindings.ml
+++ b/tests/expected_bindings.ml
@@ -13,6 +13,7 @@ external fn_four_parameters : Car.t -> int -> int -> int -> Car.t = "fn_four_par
 external fn_five_parameters : Car.t -> int -> int -> int -> int -> Car.t = "fn_five_parameters"
 external fn_six_parameters : Car.t -> int -> int -> int -> int -> int -> Car.t = "fn_six_parameters_bytecode" "fn_six_parameters"
 external test_add_i32 : int32 -> int32 -> int32 = "test_add_i32"
+external test_add_usize : int -> int -> int = "test_add_usize"
 
 module Toyota = struct 
   type nonrec t = Car.t

--- a/tests/expected_bindings.ml
+++ b/tests/expected_bindings.ml
@@ -12,6 +12,7 @@ external fn_three_parameters : Car.t -> int -> int -> Car.t = "fn_three_paramete
 external fn_four_parameters : Car.t -> int -> int -> int -> Car.t = "fn_four_parameters"
 external fn_five_parameters : Car.t -> int -> int -> int -> int -> Car.t = "fn_five_parameters"
 external fn_six_parameters : Car.t -> int -> int -> int -> int -> int -> Car.t = "fn_six_parameters_bytecode" "fn_six_parameters"
+external test_add_i32 : int32 -> int32 -> int32 = "test_add_i32"
 
 module Toyota = struct 
   type nonrec t = Car.t

--- a/tests/lib.ml
+++ b/tests/lib.ml
@@ -1,7 +1,0 @@
-let linkme = ()
-
-let () =
-  let b = Bindings.new_t () in
-  assert (b.inner = "Hello") ;
-  let c = b.inner in
-  assert (c = "Hello")

--- a/tests/ocamlgen_test.ml
+++ b/tests/ocamlgen_test.ml
@@ -2,6 +2,11 @@ let test_single_tuple_access_field () =
   let b = Bindings.new_t () in
   assert (b.inner = "Hello")
 
+let test_built_in_type_int32 () =
+  let s1 = Int32.of_int 3 in
+  let s2 = Int32.of_int 6 in
+  assert (Int32.(add s1 s2) = Bindings.test_add_i32 s1 s2)
+
 let () =
   let open Alcotest in
   run "Test binding generations"
@@ -9,4 +14,5 @@ let () =
       , [ test_case "Access field and check value" `Quick
             test_single_tuple_access_field
         ] )
+    ; ("builtin types", [ test_case "add i32" `Quick test_built_in_type_int32 ])
     ]

--- a/tests/ocamlgen_test.ml
+++ b/tests/ocamlgen_test.ml
@@ -8,9 +8,18 @@ let test_built_in_type_int32 =
       (tup2 QCheck.int32 QCheck.int32) (fun (i1, i2) ->
         Int32.(add i1 i2) = Bindings.test_add_i32 i1 i2 ) )
 
+let test_bytes_get =
+  QCheck.(
+    Test.make ~name:"Test builtin type Bytes.t with get"
+      (tup2 QCheck.bytes QCheck.int) (fun (bs, idx) ->
+        assume (idx >= 0 && idx < Bytes.length bs) ;
+        let c = Bytes.get bs idx in
+        Bindings.test_bytes_get bs idx = c ) )
+
 let () =
   let builtin_types_qcheck_suite =
-    List.map QCheck_alcotest.to_alcotest [ test_built_in_type_int32 ]
+    List.map QCheck_alcotest.to_alcotest
+      [ test_built_in_type_int32; test_bytes_get ]
   in
   let open Alcotest in
   run "Test binding generations"

--- a/tests/ocamlgen_test.ml
+++ b/tests/ocamlgen_test.ml
@@ -5,7 +5,12 @@ let test_single_tuple_access_field () =
 let test_built_in_type_int32 =
   QCheck.(
     Test.make ~name:"Test builtin type int32 with addition"
-      (tup2 QCheck.int32 QCheck.int32) (fun (i1, i2) ->
+      (tup2
+         (QCheck.int_range (-1_000_000) 1_000_000)
+         (QCheck.int_range (-1_000_000) 1_000_000) )
+      (fun (i1, i2) ->
+        let i1 = Int32.of_int i1 in
+        let i2 = Int32.of_int i2 in
         Int32.(add i1 i2) = Bindings.test_add_i32 i1 i2 ) )
 
 let test_bytes_get =

--- a/tests/ocamlgen_test.ml
+++ b/tests/ocamlgen_test.ml
@@ -2,17 +2,21 @@ let test_single_tuple_access_field () =
   let b = Bindings.new_t () in
   assert (b.inner = "Hello")
 
-let test_built_in_type_int32 () =
-  let s1 = Int32.of_int 3 in
-  let s2 = Int32.of_int 6 in
-  assert (Int32.(add s1 s2) = Bindings.test_add_i32 s1 s2)
+let test_built_in_type_int32 =
+  QCheck.(
+    Test.make ~name:"Test builtin type int32 with addition"
+      (tup2 QCheck.int32 QCheck.int32) (fun (i1, i2) ->
+        Int32.(add i1 i2) = Bindings.test_add_i32 i1 i2 ) )
 
 let () =
+  let builtin_types_qcheck_suite =
+    List.map QCheck_alcotest.to_alcotest [ test_built_in_type_int32 ]
+  in
   let open Alcotest in
   run "Test binding generations"
     [ ( "single_tuple"
       , [ test_case "Access field and check value" `Quick
             test_single_tuple_access_field
         ] )
-    ; ("builtin types", [ test_case "add i32" `Quick test_built_in_type_int32 ])
+    ; ("Builtin types", builtin_types_qcheck_suite)
     ]

--- a/tests/ocamlgen_test.ml
+++ b/tests/ocamlgen_test.ml
@@ -16,10 +16,15 @@ let test_bytes_get =
         let c = Bytes.get bs idx in
         Bindings.test_bytes_get bs idx = c ) )
 
+let test_u8_char_get_ascii_code =
+  QCheck.(
+    Test.make ~name:"Test u8 binding by getting ASCII code" QCheck.char
+      (fun c -> Int32.to_int @@ Bindings.test_get_ascii_code c = int_of_char c) )
+
 let () =
   let builtin_types_qcheck_suite =
     List.map QCheck_alcotest.to_alcotest
-      [ test_built_in_type_int32; test_bytes_get ]
+      [ test_built_in_type_int32; test_bytes_get; test_u8_char_get_ascii_code ]
   in
   let open Alcotest in
   run "Test binding generations"

--- a/tests/ocamlgen_test.ml
+++ b/tests/ocamlgen_test.ml
@@ -1,5 +1,12 @@
-(** This file is used to test executables.
-    It simply links the library so that code there is executed and tested.
-  *)
+let test_single_tuple_access_field () =
+  let b = Bindings.new_t () in
+  assert (b.inner = "Hello")
 
-let () = Ocamlgen_test_lib.Lib.linkme
+let () =
+  let open Alcotest in
+  run "Test binding generations"
+    [ ( "single_tuple"
+      , [ test_case "Access field and check value" `Quick
+            test_single_tuple_access_field
+        ] )
+    ]

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -30,6 +30,8 @@ fn main() -> std::io::Result<()> {
 
     ocaml_gen::decl_func!(w, env, test_bytes_get => "test_bytes_get");
 
+    ocaml_gen::decl_func!(w, env, test_get_ascii_code => "test_get_ascii_code");
+
     ocaml_gen::decl_module!(w, env, "Toyota", {
         ocaml_gen::decl_type_alias!(w, env, "t" => Car);
         ocaml_gen::decl_func!(w, env, create_toyota => "create_toyota");

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -25,6 +25,7 @@ fn main() -> std::io::Result<()> {
     ocaml_gen::decl_func!(w, env, fn_four_parameters => "fn_four_parameters");
     ocaml_gen::decl_func!(w, env, fn_five_parameters => "fn_five_parameters");
     ocaml_gen::decl_func!(w, env, fn_six_parameters => "fn_six_parameters");
+    ocaml_gen::decl_func!(w, env, test_add_i32 => "test_add_i32");
 
     ocaml_gen::decl_module!(w, env, "Toyota", {
         ocaml_gen::decl_type_alias!(w, env, "t" => Car);

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -26,6 +26,7 @@ fn main() -> std::io::Result<()> {
     ocaml_gen::decl_func!(w, env, fn_five_parameters => "fn_five_parameters");
     ocaml_gen::decl_func!(w, env, fn_six_parameters => "fn_six_parameters");
     ocaml_gen::decl_func!(w, env, test_add_i32 => "test_add_i32");
+    ocaml_gen::decl_func!(w, env, test_add_usize => "test_add_usize");
 
     ocaml_gen::decl_module!(w, env, "Toyota", {
         ocaml_gen::decl_type_alias!(w, env, "t" => Car);

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -28,6 +28,8 @@ fn main() -> std::io::Result<()> {
     ocaml_gen::decl_func!(w, env, test_add_i32 => "test_add_i32");
     ocaml_gen::decl_func!(w, env, test_add_usize => "test_add_usize");
 
+    ocaml_gen::decl_func!(w, env, test_bytes_get => "test_bytes_get");
+
     ocaml_gen::decl_module!(w, env, "Toyota", {
         ocaml_gen::decl_type_alias!(w, env, "t" => Car);
         ocaml_gen::decl_func!(w, env, create_toyota => "create_toyota");

--- a/tests/ocamlgen_test_stubs/src/lib/lib.rs
+++ b/tests/ocamlgen_test_stubs/src/lib/lib.rs
@@ -95,3 +95,9 @@ pub fn test_add_i32(s1: i32, s2: i32) -> i32 {
 pub fn test_add_usize(s1: usize, s2: usize) -> usize {
     s1 + s2
 }
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn test_bytes_get(s1: &[u8], i: usize) -> u8 {
+    s1[i]
+}

--- a/tests/ocamlgen_test_stubs/src/lib/lib.rs
+++ b/tests/ocamlgen_test_stubs/src/lib/lib.rs
@@ -89,3 +89,9 @@ pub fn fn_six_parameters(
 pub fn test_add_i32(s1: i32, s2: i32) -> i32 {
     s1 + s2
 }
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn test_add_usize(s1: usize, s2: usize) -> usize {
+    s1 + s2
+}

--- a/tests/ocamlgen_test_stubs/src/lib/lib.rs
+++ b/tests/ocamlgen_test_stubs/src/lib/lib.rs
@@ -101,3 +101,9 @@ pub fn test_add_usize(s1: usize, s2: usize) -> usize {
 pub fn test_bytes_get(s1: &[u8], i: usize) -> u8 {
     s1[i]
 }
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn test_get_ascii_code(ascii: u8) -> i32 {
+    ascii as i32
+}

--- a/tests/ocamlgen_test_stubs/src/lib/lib.rs
+++ b/tests/ocamlgen_test_stubs/src/lib/lib.rs
@@ -83,3 +83,9 @@ pub fn fn_six_parameters(
 ) -> Car {
     v1
 }
+// Test OCamlDesc is implemented for i32
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn test_add_i32(s1: i32, s2: i32) -> i32 {
+    s1 + s2
+}


### PR DESCRIPTION
Built on top of #12 

- [x] Documentation
- [x] remove wrong OCamlDesc impelementation for `Vec<u8>`  (this is is not `Bytes.t`)
- [x] add comments about unsigned values
- [x] add a bindidng generation for usize to keep track of the type it generates

Fix https://github.com/MinaProtocol/mina/issues/13224 and https://github.com/MinaProtocol/mina/issues/13226