### PR TITLE
Handle more than 5 parameters for ocaml_gen::func

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ _opam
 # Cargo.lock should be ignored for libraries.
 # Cargo.lock should be committed only for binaries
 Cargo.lock
+release
+.rustc_info.json

--- a/README.md
+++ b/README.md
@@ -17,6 +17,18 @@ opam switch create ./ 4.14.0
 opam install merlin ocamlformat.$(awk -F = '$1 == "version" {print $2}' .ocamlformat)
 ```
 
+## Run tests
+
+```
+dune build @runtest
+```
+
+If you change the file `tests/ocamlgen_test_stubs/src/bin/main.rs` or anything related to code generation, you will need to update `tests/expected_bindings.ml`. You can use:
+```
+dune build @runtest --auto-promote
+```
+to rely on `dune` to update the file. You will need to commit it to make the CI happy.
+
 ## Organization
 
 * [ocaml-gen](ocaml-gen): the tool that allows us to generate the OCaml bindings from the Rust code.

--- a/ocaml-gen/derive/src/lib.rs
+++ b/ocaml-gen/derive/src/lib.rs
@@ -79,11 +79,21 @@ pub fn func(_attribute: TokenStream, item: TokenStream) -> TokenStream {
             // return value
             let return_value = #return_value;
 
+            if args.len() <= 5 {
+                format!(
+                    "external {} : {} -> {} = \"{}\"",
+                    ocaml_name, inputs, return_value, #rust_name_str
+                )
+            }
+            // !! This is not the best way to handle this case. This will break
+            // if ocaml-rs changes its code generator.
+            else {
+                format!(
+                    "external {} : {} -> {} = \"{}_bytecode\" \"{}\"",
+                    ocaml_name, inputs, return_value, #rust_name_str, #rust_name_str
+                )
+            }
             // return the binding
-            format!(
-                "external {} : {} -> {} = \"{}\"",
-                ocaml_name, inputs, return_value, #rust_name_str
-            )
         }
     };
 

--- a/tests/dune
+++ b/tests/dune
@@ -27,7 +27,9 @@
       cp
       %{project_root}/target/release/libocamlgen_test_stubs.dylib
       dllocamlgen_test_stubs.so))
-    (run cargo run --bin main --release --target-dir %{project_root}/target)))))
+    (with-stdout-to
+     bindings.ml
+     (run cargo run --bin main --release --target-dir %{project_root}/target))))))
 
 ;; test library
 

--- a/tests/dune
+++ b/tests/dune
@@ -51,4 +51,7 @@
 (rule
  (alias runtest)
  (action
-  (run ./ocamlgen_test.exe)))
+  (progn
+   (run ./ocamlgen_test.exe)
+   ;; https://dune.readthedocs.io/en/stable/concepts.html#diffing-and-promotion
+   (diff expected_bindings.ml bindings.ml))))

--- a/tests/expected_bindings.ml
+++ b/tests/expected_bindings.ml
@@ -6,6 +6,12 @@ module Car = struct
   type nonrec t
 end
 
+external fn_one_parameter : Car.t -> Car.t = "fn_one_parameter"
+external fn_two_parameters : Car.t -> int -> Car.t = "fn_two_parameters"
+external fn_three_parameters : Car.t -> int -> int -> Car.t = "fn_three_parameters"
+external fn_four_parameters : Car.t -> int -> int -> int -> Car.t = "fn_four_parameters"
+external fn_five_parameters : Car.t -> int -> int -> int -> int -> Car.t = "fn_five_parameters"
+external fn_six_parameters : Car.t -> int -> int -> int -> int -> int -> Car.t = "fn_six_parameters_bytecode" "fn_six_parameters"
 
 module Toyota = struct 
   type nonrec t = Car.t

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -18,6 +18,8 @@ fn main() -> std::io::Result<()> {
         ocaml_gen::decl_type!(w, env, Car => "t");
     });
 
+    ocaml_gen::decl_func!(w, env, fn_with_more_than_5_parameters => "more_than_5_parameters");
+
     ocaml_gen::decl_module!(w, env, "Toyota", {
         ocaml_gen::decl_type_alias!(w, env, "t" => Car);
         ocaml_gen::decl_func!(w, env, create_toyota => "create_toyota");

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -2,7 +2,8 @@ use ocaml_gen::prelude::*;
 use ocamlgen_test_stubs::*;
 
 use std::fmt::Write as _;
-use std::fs;
+use std::io;
+use std::io::Write;
 
 fn main() -> std::io::Result<()> {
     let mut w = String::new();
@@ -39,6 +40,6 @@ fn main() -> std::io::Result<()> {
         ocaml_gen::decl_func!(w, env, pack_present => "pack_present");
     });
 
-    fs::write("bindings.ml", w)?;
+    io::stdout().write_all(w.as_bytes())?;
     Ok(())
 }

--- a/tests/ocamlgen_test_stubs/src/bin/main.rs
+++ b/tests/ocamlgen_test_stubs/src/bin/main.rs
@@ -18,7 +18,12 @@ fn main() -> std::io::Result<()> {
         ocaml_gen::decl_type!(w, env, Car => "t");
     });
 
-    ocaml_gen::decl_func!(w, env, fn_with_more_than_5_parameters => "more_than_5_parameters");
+    ocaml_gen::decl_func!(w, env, fn_one_parameter => "fn_one_parameter");
+    ocaml_gen::decl_func!(w, env, fn_two_parameters => "fn_two_parameters");
+    ocaml_gen::decl_func!(w, env, fn_three_parameters => "fn_three_parameters");
+    ocaml_gen::decl_func!(w, env, fn_four_parameters => "fn_four_parameters");
+    ocaml_gen::decl_func!(w, env, fn_five_parameters => "fn_five_parameters");
+    ocaml_gen::decl_func!(w, env, fn_six_parameters => "fn_six_parameters");
 
     ocaml_gen::decl_module!(w, env, "Toyota", {
         ocaml_gen::decl_type_alias!(w, env, "t" => Car);

--- a/tests/ocamlgen_test_stubs/src/lib/lib.rs
+++ b/tests/ocamlgen_test_stubs/src/lib/lib.rs
@@ -40,3 +40,16 @@ pub fn pack_present() -> Package<String> {
         gift: "hello".to_string(),
     }
 }
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn fn_with_more_than_5_parameters(
+    v1: Car,
+    _v2: usize,
+    _v3: usize,
+    _v4: usize,
+    _v5: usize,
+    _v6: usize,
+) -> Car {
+    v1
+}

--- a/tests/ocamlgen_test_stubs/src/lib/lib.rs
+++ b/tests/ocamlgen_test_stubs/src/lib/lib.rs
@@ -43,7 +43,37 @@ pub fn pack_present() -> Package<String> {
 
 #[ocaml_gen::func]
 #[ocaml::func]
-pub fn fn_with_more_than_5_parameters(
+pub fn fn_one_parameter(v1: Car) -> Car {
+    v1
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn fn_two_parameters(v1: Car, _v2: usize) -> Car {
+    v1
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn fn_three_parameters(v1: Car, _v2: usize, _v3: usize) -> Car {
+    v1
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn fn_four_parameters(v1: Car, _v2: usize, _v3: usize, _v4: usize) -> Car {
+    v1
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn fn_five_parameters(v1: Car, _v2: usize, _v3: usize, _v4: usize, _v5: usize) -> Car {
+    v1
+}
+
+#[ocaml_gen::func]
+#[ocaml::func]
+pub fn fn_six_parameters(
     v1: Car,
     _v2: usize,
     _v3: usize,


### PR DESCRIPTION
Fix #10.