### PR TITLE
Get rid of action-rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
             ./rustup-init -y --default-toolchain "${{ matrix.rust_toolchain_version }}" --profile default
             rm ./rustup-init
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            # overwriting default rust-toolchain
+            echo ${{ matrix.rust_toolchain_version }} > rust-toolchain
 
       - name: Setup OCaml ${{ matrix.ocaml_version }}
         uses: ocaml/setup-ocaml@v2
@@ -98,4 +100,4 @@ jobs:
 
       - name: Check that up-to-date bindings are checked in
         run: |
-          git diff --exit-code
+          git diff --exit-code ":(exclude)rust-toolchain"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,20 +35,19 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v2
 
-      - name: Set up cargo/rust ${{ matrix.rust_toolchain_version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          # Using default to get rust-docs, rustfmt and clippy
-          # Doc: https://rust-lang.github.io/rustup/concepts/profiles.html
-          profile: default
-          toolchain: ${{ matrix.rust_toolchain_version }}
-          # Override the default toolchain. This is required in the case of
-          # bugfixing release of rust.
-          override: true
+      # as action-rs does not seem to be maintained anymore, building from
+      # scratch the environment using rustup
+      - name: Setup Rust toolchain ${{ matrix.rust_toolchain_version }}
+        run:
+          |
+            curl --proto '=https' --tlsv1.2 -sSf -o rustup-init \
+            https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
+            chmod +x ./rustup-init
+            ./rustup-init -y --default-toolchain "${{ matrix.rust_toolchain_version }}" --profile default
+            rm ./rustup-init
+            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      # Important to setup OCaml before running lint because linting requires an
-      # OCaml version installed on the machine
-      - name: Setup OCaml ${{ matrix.ocaml_version }} (because of ocaml-gen)
+      - name: Setup OCaml ${{ matrix.ocaml_version }}
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml_version }}
@@ -57,23 +56,29 @@ jobs:
 
       - name: Setup OCaml dependencies
         run: |
+          eval $(opam env)
           opam install . --deps-only --with-test
+
+      - name: List OCaml and Rust versions
+        run: |
+          eval $(opam env)
+          echo "OCaml version $(ocamlc --version) (location = $(which ocamlc))"
+          echo "OPAM version $(opam --version) (location = $(which opam))"
+          echo "Rust version $(rustc --version) (location = $(which rustc))"
 
       #
       # Coding guidelines
       #
 
       - name: Enforce Rust formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: -- --check
+        run: |
+            eval $(opam env)
+            cargo run fmt -- --check
 
       - name: Lint (clippy)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all --features=without-ocamlopt -- -D warnings
+        run: |
+            eval $(opam env)
+            cargo run clippy --all -- -D warnings
 
       - name: Enforce OCaml formatting
         run: |

--- a/dune-project
+++ b/dune-project
@@ -16,6 +16,5 @@
  (depends
   (dune (>= 3.0))
   (ocaml (and (>= 4.12) (< 5.0)))
-  (conf-rust (>= 0.1))
  )
 )

--- a/ocamlgen-test.opam
+++ b/ocamlgen-test.opam
@@ -9,7 +9,6 @@ bug-reports: "https://github.com/o1-labs/ocaml-gen/issues"
 depends: [
   "dune" {>= "3.0" & >= "3.0"}
   "ocaml" {>= "4.12" & < "5.0"}
-  "conf-rust" {>= "0.1"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
As discussed online, action-rs does not seem to be maintained anymore.
It has been decided to change the jobs to use in-house setup.
setup-ocaml GH actions is maintained by the OCaml community, therefore it seems fair to use it on the long term.
proof-systems will be changed to use the same template.