### PR TITLE
README: remove publishing directives + 80 characters friendliness

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The goal of `ocaml-gen` and `ocaml-gen-derive` is to provide automatic binding
 generations and to add macros easing the development of large applications.
 It is meant to be used in conjunction with [`ocaml-rs`](https://github.com/zshipko/ocaml-rs).
 
-**SECURITY WARNING: this is still an experimental library, you should verify that the bindings generated are correct if you are using this in production**.
+**SECURITY WARNING: this is still an experimental library, you should verify
+that the bindings generated are correct if you are using this in production**.
 
 See the [ocaml-gen/README](/ocaml-gen) for more information.
 
@@ -42,18 +43,29 @@ opam install merlin ocamlformat.$(awk -F = '$1 == "version" {print $2}' .ocamlfo
 dune build @runtest
 ```
 
-If you change the file `tests/ocamlgen_test_stubs/src/bin/main.rs` or anything related to code generation, you will need to update `tests/expected_bindings.ml`. You can use:
-```
+If you change the file `tests/ocamlgen_test_stubs/src/bin/main.rs` or anything
+related to code generation, you will need to update
+`tests/expected_bindings.ml`. You can use:
+
+```shell
 dune build @runtest --auto-promote
 ```
-to rely on `dune` to update the file. You will need to commit it to make the CI happy.
+
+to rely on `dune` to update the file. You will need to commit it to make the CI
+happy.
 
 ## Organization
 
-* [ocaml-gen](ocaml-gen): the tool that allows us to generate the OCaml bindings from the Rust code.
-* [ocaml-gen-derive](ocaml-gen/derive): derive macros have to be a in separate crate, so they are here. This crate is re-exported by ocaml-gen so end users should not have to worry about it.
-* [tests/](tests/): contains some tests. If you are looking for examples on how to use ocaml-gen, you can check that folder.
+* [ocaml-gen](ocaml-gen): the tool that allows us to generate the OCaml bindings
+  from the Rust code.
+* [ocaml-gen-derive](ocaml-gen/derive): derive macros have to be a in separate
+  crate, so they are here. This crate is re-exported by ocaml-gen so end users
+  should not have to worry about it.
+* [tests/](tests/): contains some tests. If you are looking for examples on how
+  to use ocaml-gen, you can check that folder.
 
 ## Additional resources
 
-You can check the [recording](https://www.youtube.com/watch?v=LuXo2cNkgyA&feature=youtu.be) I made when I first introduced the tool internally.
+You can check the
+[recording](https://www.youtube.com/watch?v=LuXo2cNkgyA&feature=youtu.be) I made
+when I first introduced the tool internally.

--- a/README.md
+++ b/README.md
@@ -57,13 +57,3 @@ to rely on `dune` to update the file. You will need to commit it to make the CI 
 ## Additional resources
 
 You can check the [recording](https://www.youtube.com/watch?v=LuXo2cNkgyA&feature=youtu.be) I made when I first introduced the tool internally.
-
-## Publish a new release
-
-An automatic release is set up with GitHub actions. To make a new release of
-ocaml-gen and ocaml-gen-derive:
-
-1. Change the version of `ocaml-gen-derive` in `ocaml-gen/Cargo.toml` to the new
-   release version.
-2. Create a tag with `git tag -m "VERSION" -a "x.y.z"`
-3. Push the tag with `git push --tags`

--- a/README.md
+++ b/README.md
@@ -69,3 +69,17 @@ happy.
 You can check the
 [recording](https://www.youtube.com/watch?v=LuXo2cNkgyA&feature=youtu.be) I made
 when I first introduced the tool internally.
+
+## Publish a new release
+
+To make a new release of ocaml-gen and ocaml-gen-derive:
+
+1. Change the CHANGELOG.md to include all unreleased features into the new
+   release. Create a new empty "Unreleased" section.
+2. Change the version of `ocaml-gen-derive` in `ocaml-gen/Cargo.toml` to the new
+   release version.
+3. Create a tag with `git tag -m "VERSION" -a "x.y.z"`
+4. Push the tag with `git push --tags`
+5. Refer to
+   [cargo-publish](https://doc.rust-lang.org/cargo/commands/cargo-publish.html)
+   to update to the public registry.


### PR DESCRIPTION
For more context about the removing of the automatic publish. It has been removed in https://github.com/o1-labs/ocaml-gen/pull/23 when the hack with Ledger and connect-kit happened: https://www.ledger.com/blog/a-letter-from-ledger-chairman-ceo-pascal-gauthier-regarding-ledger-connect-kit-exploit.

We must never automate release of packages.