### PR TITLE
CI: add macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
         # It might be related to boxroot dependency, and we would need to bump
         # up the ocaml-rs dependency
         ocaml_version: [4.14]
-
-    runs-on: ubuntu-latest
+        os: ["macos-latest", "ubuntu-latest"]
+    runs-on: ${{ matrix.os }}
     name: Run some basic checks and tests
     steps:
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,10 @@ jobs:
       - name: Setup Rust toolchain ${{ matrix.rust_toolchain_version }}
         run:
           |
-            curl --proto '=https' --tlsv1.2 -sSf -o rustup-init \
-            https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
-            chmod +x ./rustup-init
-            ./rustup-init -y --default-toolchain "${{ matrix.rust_toolchain_version }}" --profile default
-            rm ./rustup-init
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+            $HOME/.cargo/bin/rustup toolchain install ${{ matrix.rust_toolchain_version }} --profile default
+            $HOME/.cargo/bin/rustup default ${{ matrix.rust_toolchain_version }}
             # overwriting default rust-toolchain
             echo ${{ matrix.rust_toolchain_version }} > rust-toolchain
 

--- a/ocaml-gen/Cargo.toml
+++ b/ocaml-gen/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/o1-labs/ocaml-gen"
 
 [lib]
 doctest = false
+# Important: do not ask to build a dynamic library.
+# On MacOS arm64, ocaml-rs.v0.2.2 causes build issues.
+crate-type = ["lib", "staticlib"]
 
 [dependencies]
 const-random.workspace = true

--- a/ocaml-gen/derive/Cargo.toml
+++ b/ocaml-gen/derive/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/o1-labs/ocaml-gen"
 [lib]
 proc-macro = true
 doctest = false
+# Important: do not ask to build a dynamic library.
+# On MacOS arm64, ocaml-rs.v0.2.2 causes build issues.
+crate-type = ["lib", "staticlib"]
 
 [dependencies]
 convert_case.workspace = true


### PR DESCRIPTION
In addition to testing MacOS compatibility, it gives us a check for [arm64 support for free](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).
![image](https://github.com/user-attachments/assets/a7786251-a313-455f-89ac-22d8bb62c3c6)

