### PR TITLE
CI: add up to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   run_checks:
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79", "1.80", "1.81", "1.82"]
+        rust_toolchain_version: ["1.79", "1.80", "1.81", "1.82", "1.83", "1.84", "1.85"]
         # Follow ocamlgen-test.opam requirements
         # FIXME: currently not available for 5.0.0.
         # It might be related to boxroot dependency, and we would need to bump


### PR DESCRIPTION
Note that versions before 1.82 will be dropped later, when Mina will have been upgraded to 1.82.