### PR TITLE
Cargo: relax constraints on deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,10 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-convert_case = "0.6.0"
+convert_case = "*"
 ocaml = "0.22.4"
-const-random = "0.1.13"
-paste = "1.0.9"
-proc-macro2 = "1.0.43"
-quote = "1.0.21"
-syn = { version = "1.0.99", features = ["full"] }
+const-random = "*"
+paste = "*"
+proc-macro2 = "*"
+quote = "*"
+syn = { version = "*", features = ["full"] }

--- a/ocaml-gen/derive/src/lib.rs
+++ b/ocaml-gen/derive/src/lib.rs
@@ -329,7 +329,7 @@ pub fn derive_ocaml_enum(item: TokenStream) -> TokenStream {
     };
     for generic in &item_enum.generics.params {
         if let GenericParam::Type(t) = generic {
-            let mut bounds = Punctuated::<TypeParamBound, syn::token::Add>::new();
+            let mut bounds = Punctuated::<TypeParamBound, syn::token::Plus>::new();
             bounds.push(TypeParamBound::Trait(impl_ocaml_desc.clone()));
 
             let path: syn::Path = syn::parse_str(&t.ident.to_string()).unwrap();
@@ -614,7 +614,7 @@ pub fn derive_ocaml_gen(item: TokenStream) -> TokenStream {
     };
     for generic in generics {
         if let GenericParam::Type(t) = generic {
-            let mut bounds = Punctuated::<TypeParamBound, syn::token::Add>::new();
+            let mut bounds = Punctuated::<TypeParamBound, syn::token::Plus>::new();
             bounds.push(TypeParamBound::Trait(impl_ocaml_desc.clone()));
 
             let path: syn::Path = syn::parse_str(&t.ident.to_string()).unwrap();


### PR DESCRIPTION
The constraints were not actually used. No need to enforce. It gives more flexibility for the packages using the library.