### PR TITLE
Prepare release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### MISC
 
+- Add CHANGELOG.md (https://github.com/o1-labs/ocaml-gen/pull/32)
 - Cargo: reorganize workspace (https://github.com/o1-labs/ocaml-gen/pull/26)
 - CI: bump up setup-ocaml and actions/checkout (https://github.com/o1-labs/ocaml-gen/pull/25)
 - Makefile: add and use in CI (https://github.com/o1-labs/ocaml-gen/pull/30)
+- CI: support Ubuntu 24.04-arm (https://github.com/o1-labs/ocaml-gen/pull/36, https://github.com/o1-labs/ocaml-gen/pull/37)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Support Rust up to 1.82 (https://github.com/o1-labs/ocaml-gen/pull/31,
   https://github.com/o1-labs/ocaml-gen/pull/29)
 - Dropping support for OCaml before 4.14.0 (https://github.com/o1-labs/ocaml-gen/pull/28)
+- Provide a no-std support (https://github.com/o1-labs/ocaml-gen/pull/40)
 
 ### MISC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.0.0
+
 - Support Rust up to 1.82 (https://github.com/o1-labs/ocaml-gen/pull/31,
   https://github.com/o1-labs/ocaml-gen/pull/29)
 - Dropping support for OCaml before 4.14.0 (https://github.com/o1-labs/ocaml-gen/pull/28)

--- a/ocaml-gen/Cargo.toml
+++ b/ocaml-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-gen"
-version = "0.1.5"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for generating OCaml code"

--- a/ocaml-gen/derive/Cargo.toml
+++ b/ocaml-gen/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-gen-derive"
-version = "0.1.5"
+version = "1.0.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "The inner library of ocaml-gen, for generating OCaml code"


### PR DESCRIPTION
The release will be used, in particular, in [this update](https://github.com/o1-labs/proof-systems/pull/3180) on proof-systems.