### PR TITLE
ci: add stable Rust version to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   run_checks:
     strategy:
       matrix:
-        rust_toolchain_version: ["1.79", "1.80", "1.81", "1.82"]
+        rust_toolchain_version: ["1.79", "1.80", "1.81", "1.82", "stable"]
         # Follow ocamlgen-test.opam requirements
         ocaml_version: [4.14, 5.2]
         os: ["ubuntu-latest", "ubuntu-24.04-arm"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
 
-- Bumped ocaml-rs from `0.22.4` to `1.3.0` so to support OCaml5
+### Changes
+
+- **Dependencies**: bump ocaml-rs from `0.22.4` to `1.3.0` to support OCaml5
+- **CI**: add stable Rust version to test matrix
+  ([#46](https://github.com/o1-labs/ocaml-gen/pull/46))
 
 ## 1.0.0
 


### PR DESCRIPTION
## Summary
- Adds `stable` Rust version to the CI test matrix
- First step toward removing older Rust versions incrementally

## Test plan
- [x] CI passes on all Rust versions including stable

Fix https://github.com/o1-labs/mina-rust/issues/1919